### PR TITLE
Feature survey result to json (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ The `SurveyResult` contains a list of `StepResult`s and the `FinishReason`. The 
     },
 )
 ```
+### Export the results to JSON
+After obtaining the `SurveyResult` object in the callback described above, you can use its `toJson()` method to either print the results in a json format, or to pass that json (Map) object on, and for example store it (in your DB, SharedPreferences, as a separate file etc.)
+```dart
+ SurveyKit(
+    onResult: (SurveyResult result) {
+      final jsonResult = result.toJson();
+      // print the json-formatted results
+      debugPrint(jsonEncode(jsonResult));
+      // or store them
+      yourDbHandler.store(jsonResult);
+    },
+)
+```
 
 ### Style
 There are already many adaptive elements for Android and IOS implemented. In the future development other parts will be adapted too.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   bloc:
     dependency: transitive
     description:
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/answer_format/multi_double.dart
+++ b/lib/src/answer_format/multi_double.dart
@@ -13,9 +13,9 @@ class MultiDouble {
   }) : super();
 
   factory MultiDouble.fromJson(Map<String, dynamic> json) =>
-      _$DoubleChoiceFromJson(json);
-  Map<String, dynamic> toJson() => _$DoubleChoiceToJson(this);
+      _$MultiDoubleFromJson(json);
+  Map<String, dynamic> toJson() => _$MultiDoubleToJson(this);
 
   bool operator ==(o) => o is MultiDouble && text == o.text && value == o.value;
-  int get hasCode => text.hashCode ^ value.hashCode;
+  int get hashCode => text.hashCode ^ value.hashCode;
 }

--- a/lib/src/answer_format/multi_double.g.dart
+++ b/lib/src/answer_format/multi_double.g.dart
@@ -6,12 +6,12 @@ part of 'multi_double.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-MultiDouble _$DoubleChoiceFromJson(Map<String, dynamic> json) => MultiDouble(
+MultiDouble _$MultiDoubleFromJson(Map<String, dynamic> json) => MultiDouble(
       text: json['text'] as String,
-      value: json['value'] as double,
+      value: (json['value'] as num).toDouble(),
     );
 
-Map<String, dynamic> _$DoubleChoiceToJson(MultiDouble instance) =>
+Map<String, dynamic> _$MultiDoubleToJson(MultiDouble instance) =>
     <String, dynamic>{
       'text': instance.text,
       'value': instance.value,

--- a/lib/src/answer_format/multiple_double_answer_format.dart
+++ b/lib/src/answer_format/multiple_double_answer_format.dart
@@ -16,6 +16,6 @@ class MultipleDoubleAnswerFormat implements AnswerFormat {
   }) : super();
 
   factory MultipleDoubleAnswerFormat.fromJson(Map<String, dynamic> json) =>
-      _$DoubleAnswerFormatFromJson(json);
-  Map<String, dynamic> toJson() => _$DoubleAnswerFormatToJson(this);
+      _$MultipleDoubleAnswerFormatFromJson(json);
+  Map<String, dynamic> toJson() => _$MultipleDoubleAnswerFormatToJson(this);
 }

--- a/lib/src/answer_format/multiple_double_answer_format.g.dart
+++ b/lib/src/answer_format/multiple_double_answer_format.g.dart
@@ -6,16 +6,18 @@ part of 'multiple_double_answer_format.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-MultipleDoubleAnswerFormat _$DoubleAnswerFormatFromJson(
+MultipleDoubleAnswerFormat _$MultipleDoubleAnswerFormatFromJson(
         Map<String, dynamic> json) =>
     MultipleDoubleAnswerFormat(
       defaultValues: (json['defaultValues'] as List<dynamic>?)
           ?.map((e) => MultiDouble.fromJson(e as Map<String, dynamic>))
           .toList(),
-      hints: (json['hints'] as List<dynamic>).map((e) => e as String).toList(),
+      hints:
+          (json['hints'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+              [],
     );
 
-Map<String, dynamic> _$DoubleAnswerFormatToJson(
+Map<String, dynamic> _$MultipleDoubleAnswerFormatToJson(
         MultipleDoubleAnswerFormat instance) =>
     <String, dynamic>{
       'defaultValues': instance.defaultValues,

--- a/lib/src/result/question/boolean_question_result.dart
+++ b/lib/src/result/question/boolean_question_result.dart
@@ -2,6 +2,11 @@ import 'package:survey_kit/src/answer_format/boolean_answer_format.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'boolean_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class BooleanQuestionResult extends QuestionResult<BooleanResult?> {
   BooleanQuestionResult({
     required Identifier id,
@@ -16,4 +21,11 @@ class BooleanQuestionResult extends QuestionResult<BooleanResult?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory BooleanQuestionResult.fromJson(Map<String, dynamic> json) => _$BooleanQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BooleanQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/boolean_question_result.g.dart
+++ b/lib/src/result/question/boolean_question_result.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'boolean_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+BooleanQuestionResult _$BooleanQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    BooleanQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: $enumDecodeNullable(_$BooleanResultEnumMap, json['result']),
+    );
+
+Map<String, dynamic> _$BooleanQuestionResultToJson(
+        BooleanQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': _$BooleanResultEnumMap[instance.result],
+      'valueIdentifier': instance.valueIdentifier,
+    };
+
+const _$BooleanResultEnumMap = {
+  BooleanResult.NONE: 'NONE',
+  BooleanResult.POSITIVE: 'POSITIVE',
+  BooleanResult.NEGATIVE: 'NEGATIVE',
+};

--- a/lib/src/result/question/date_question_result.dart
+++ b/lib/src/result/question/date_question_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/result/question_result.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'date_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class DateQuestionResult extends QuestionResult<DateTime?> {
   DateQuestionResult({
     required Identifier id,
@@ -15,4 +20,11 @@ class DateQuestionResult extends QuestionResult<DateTime?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory DateQuestionResult.fromJson(Map<String, dynamic> json) => _$DateQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DateQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/date_question_result.g.dart
+++ b/lib/src/result/question/date_question_result.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'date_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DateQuestionResult _$DateQuestionResultFromJson(Map<String, dynamic> json) =>
+    DateQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: json['result'] == null
+          ? null
+          : DateTime.parse(json['result'] as String),
+    );
+
+Map<String, dynamic> _$DateQuestionResultToJson(DateQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result?.toIso8601String(),
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/double_question_result.dart
+++ b/lib/src/result/question/double_question_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'double_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class DoubleQuestionResult extends QuestionResult<double?> {
   DoubleQuestionResult({
     required Identifier id,
@@ -15,4 +20,11 @@ class DoubleQuestionResult extends QuestionResult<double?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory DoubleQuestionResult.fromJson(Map<String, dynamic> json) => _$DoubleQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DoubleQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/double_question_result.g.dart
+++ b/lib/src/result/question/double_question_result.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'double_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DoubleQuestionResult _$DoubleQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    DoubleQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: (json['result'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$DoubleQuestionResultToJson(
+        DoubleQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result,
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/integer_question_result.dart
+++ b/lib/src/result/question/integer_question_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'integer_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class IntegerQuestionResult extends QuestionResult<int?> {
   IntegerQuestionResult({
     required Identifier id,
@@ -15,4 +20,11 @@ class IntegerQuestionResult extends QuestionResult<int?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory IntegerQuestionResult.fromJson(Map<String, dynamic> json) => _$IntegerQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$IntegerQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/integer_question_result.g.dart
+++ b/lib/src/result/question/integer_question_result.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'integer_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+IntegerQuestionResult _$IntegerQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    IntegerQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: json['result'] as int?,
+    );
+
+Map<String, dynamic> _$IntegerQuestionResultToJson(
+        IntegerQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result,
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/multiple_choice_question_result.dart
+++ b/lib/src/result/question/multiple_choice_question_result.dart
@@ -2,6 +2,11 @@ import 'package:survey_kit/src/answer_format/text_choice.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'multiple_choice_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class MultipleChoiceQuestionResult extends QuestionResult<List<TextChoice>?> {
   MultipleChoiceQuestionResult({
     required Identifier id,
@@ -16,4 +21,11 @@ class MultipleChoiceQuestionResult extends QuestionResult<List<TextChoice>?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory MultipleChoiceQuestionResult.fromJson(Map<String, dynamic> json) => _$MultipleChoiceQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MultipleChoiceQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/multiple_choice_question_result.g.dart
+++ b/lib/src/result/question/multiple_choice_question_result.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'multiple_choice_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MultipleChoiceQuestionResult _$MultipleChoiceQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    MultipleChoiceQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: (json['result'] as List<dynamic>?)
+          ?.map((e) => TextChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$MultipleChoiceQuestionResultToJson(
+        MultipleChoiceQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result?.map((e) => e.toJson()).toList(),
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/multiple_double_question_result.dart
+++ b/lib/src/result/question/multiple_double_question_result.dart
@@ -2,18 +2,30 @@ import 'package:survey_kit/src/answer_format/multi_double.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'multiple_double_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class MultipleDoubleQuestionResult extends QuestionResult<List<MultiDouble>?> {
   MultipleDoubleQuestionResult({
     required Identifier id,
     required DateTime startDate,
     required DateTime endDate,
     required String valueIdentifier,
-    required List<MultiDouble> results,
+    required List<MultiDouble>? result,
   }) : super(
           id: id,
           startDate: startDate,
           endDate: endDate,
           valueIdentifier: valueIdentifier,
-          result: results,
+          result: result,
         );
+
+  factory MultipleDoubleQuestionResult.fromJson(Map<String, dynamic> json) => _$MultipleDoubleQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MultipleDoubleQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/multiple_double_question_result.g.dart
+++ b/lib/src/result/question/multiple_double_question_result.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'multiple_double_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MultipleDoubleQuestionResult _$MultipleDoubleQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    MultipleDoubleQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: (json['result'] as List<dynamic>?)
+          ?.map((e) => MultiDouble.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$MultipleDoubleQuestionResultToJson(
+        MultipleDoubleQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result?.map((e) => e.toJson()).toList(),
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/scale_question_result.dart
+++ b/lib/src/result/question/scale_question_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'scale_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class ScaleQuestionResult extends QuestionResult<double?> {
   ScaleQuestionResult({
     required Identifier id,
@@ -15,4 +20,11 @@ class ScaleQuestionResult extends QuestionResult<double?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory ScaleQuestionResult.fromJson(Map<String, dynamic> json) => _$ScaleQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ScaleQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/scale_question_result.g.dart
+++ b/lib/src/result/question/scale_question_result.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'scale_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ScaleQuestionResult _$ScaleQuestionResultFromJson(Map<String, dynamic> json) =>
+    ScaleQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: (json['result'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$ScaleQuestionResultToJson(
+        ScaleQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result,
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/single_choice_question_result.dart
+++ b/lib/src/result/question/single_choice_question_result.dart
@@ -2,6 +2,11 @@ import 'package:survey_kit/src/answer_format/text_choice.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'single_choice_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class SingleChoiceQuestionResult extends QuestionResult<TextChoice?> {
   SingleChoiceQuestionResult({
     required Identifier id,
@@ -16,4 +21,11 @@ class SingleChoiceQuestionResult extends QuestionResult<TextChoice?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory SingleChoiceQuestionResult.fromJson(Map<String, dynamic> json) => _$SingleChoiceQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SingleChoiceQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/single_choice_question_result.g.dart
+++ b/lib/src/result/question/single_choice_question_result.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'single_choice_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SingleChoiceQuestionResult _$SingleChoiceQuestionResultFromJson(
+        Map<String, dynamic> json) =>
+    SingleChoiceQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: json['result'] == null
+          ? null
+          : TextChoice.fromJson(json['result'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$SingleChoiceQuestionResultToJson(
+        SingleChoiceQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result?.toJson(),
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/text_question_result.dart
+++ b/lib/src/result/question/text_question_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'text_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class TextQuestionResult extends QuestionResult<String?> {
   TextQuestionResult({
     required Identifier id,
@@ -15,4 +20,11 @@ class TextQuestionResult extends QuestionResult<String?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory TextQuestionResult.fromJson(Map<String, dynamic> json) => _$TextQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TextQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
 }

--- a/lib/src/result/question/text_question_result.g.dart
+++ b/lib/src/result/question/text_question_result.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'text_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TextQuestionResult _$TextQuestionResultFromJson(Map<String, dynamic> json) =>
+    TextQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: json['result'] as String?,
+    );
+
+Map<String, dynamic> _$TextQuestionResultToJson(TextQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result,
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/question/time_question_result.dart
+++ b/lib/src/result/question/time_question_result.dart
@@ -2,6 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'time_question_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+@TimeOfDayConverter()
 class TimeQuestionResult extends QuestionResult<TimeOfDay?> {
   TimeQuestionResult({
     required Identifier id,
@@ -16,4 +22,63 @@ class TimeQuestionResult extends QuestionResult<TimeOfDay?> {
           valueIdentifier: valueIdentifier,
           result: result,
         );
+
+  factory TimeQuestionResult.fromJson(Map<String, dynamic> json) =>
+      _$TimeQuestionResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TimeQuestionResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier, result];
+}
+
+class TimeOfDayConverter extends JsonConverter<TimeOfDay?, String?> {
+  const TimeOfDayConverter();
+
+  @override
+  TimeOfDay? fromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+
+    String _removeLeadingZeroIfNeeded(String value) {
+      if (value.startsWith('0')) {
+        const indexOfSecondCharacter = 1;
+        return value.substring(indexOfSecondCharacter);
+      } else {
+        return value;
+      }
+    }
+
+    final elements = json.split(':');
+    final hourString = _removeLeadingZeroIfNeeded(elements.first);
+    final minuteString = _removeLeadingZeroIfNeeded(elements.last);
+
+    final hour = int.tryParse(hourString);
+    final minute = int.tryParse(minuteString);
+
+    if (hour != null && minute != null) {
+      return TimeOfDay(hour: hour, minute: minute);
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  String? toJson(TimeOfDay? object) {
+    if (object == null) {
+      return null;
+    }
+
+    String _addLeadingZeroIfNeeded(int value) {
+      if (value < 10)
+        return '0$value';
+      return value.toString();
+    }
+
+    final String hourLabel = _addLeadingZeroIfNeeded(object.hour);
+    final String minuteLabel = _addLeadingZeroIfNeeded(object.minute);
+
+    return '$hourLabel:$minuteLabel';
+  }
 }

--- a/lib/src/result/question/time_question_result.g.dart
+++ b/lib/src/result/question/time_question_result.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'time_question_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TimeQuestionResult _$TimeQuestionResultFromJson(Map<String, dynamic> json) =>
+    TimeQuestionResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      valueIdentifier: json['valueIdentifier'] as String,
+      result: const TimeOfDayConverter().fromJson(json['result'] as String?),
+    );
+
+Map<String, dynamic> _$TimeQuestionResultToJson(TimeQuestionResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': const TimeOfDayConverter().toJson(instance.result),
+      'valueIdentifier': instance.valueIdentifier,
+    };

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -1,6 +1,7 @@
+import 'package:equatable/equatable.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 
-abstract class Result {
+abstract class Result extends Equatable {
   final Identifier? id;
   final DateTime startDate;
   final DateTime endDate;

--- a/lib/src/result/step/completion_step_result.dart
+++ b/lib/src/result/step/completion_step_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'completion_step_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class CompletionStepResult extends QuestionResult {
   CompletionStepResult(
     Identifier id,
@@ -13,4 +18,11 @@ class CompletionStepResult extends QuestionResult {
           valueIdentifier: 'completion',
           result: null,
         );
+  factory CompletionStepResult.fromJson(Map<String, dynamic> json) =>
+      _$CompletionStepResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CompletionStepResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier];
 }

--- a/lib/src/result/step/completion_step_result.g.dart
+++ b/lib/src/result/step/completion_step_result.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'completion_step_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CompletionStepResult _$CompletionStepResultFromJson(
+        Map<String, dynamic> json) =>
+    CompletionStepResult(
+      Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      DateTime.parse(json['startDate'] as String),
+      DateTime.parse(json['endDate'] as String),
+    );
+
+Map<String, dynamic> _$CompletionStepResultToJson(
+        CompletionStepResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+    };

--- a/lib/src/result/step/instruction_step_result.dart
+++ b/lib/src/result/step/instruction_step_result.dart
@@ -1,6 +1,11 @@
 import 'package:survey_kit/src/result/question_result.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'instruction_step_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class InstructionStepResult extends QuestionResult {
   InstructionStepResult(
     Identifier id,
@@ -13,4 +18,11 @@ class InstructionStepResult extends QuestionResult {
           valueIdentifier: 'instruction',
           result: null,
         );
+  factory InstructionStepResult.fromJson(Map<String, dynamic> json) =>
+      _$InstructionStepResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$InstructionStepResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier];
 }

--- a/lib/src/result/step/instruction_step_result.g.dart
+++ b/lib/src/result/step/instruction_step_result.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'instruction_step_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+InstructionStepResult _$InstructionStepResultFromJson(
+        Map<String, dynamic> json) =>
+    InstructionStepResult(
+      Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      DateTime.parse(json['startDate'] as String),
+      DateTime.parse(json['endDate'] as String),
+    );
+
+Map<String, dynamic> _$InstructionStepResultToJson(
+        InstructionStepResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+    };

--- a/lib/src/result/step/video_step_result.dart
+++ b/lib/src/result/step/video_step_result.dart
@@ -1,24 +1,43 @@
 import 'package:survey_kit/src/result/question_result.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'video_step_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class VideoStepResult extends QuestionResult<VideoResult> {
   VideoStepResult({
     required Identifier id,
     required DateTime startDate,
     required DateTime endDate,
-    required VideoResult videoResult,
+    required VideoResult result,
   }) : super(
           id: id,
           startDate: startDate,
           endDate: endDate,
           valueIdentifier: id.id,
-          result: videoResult,
+          result: result,
         );
+  factory VideoStepResult.fromJson(Map<String, dynamic> json) =>
+      _$VideoStepResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VideoStepResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, valueIdentifier];
 }
 
+@JsonSerializable(explicitToJson: true)
 class VideoResult {
   final Duration leftVideoAt;
   final DateTime stayedInVideo;
+
+  factory VideoResult.fromJson(Map<String, dynamic> json) =>
+      _$VideoResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VideoResultToJson(this);
+
 
   const VideoResult({
     required this.leftVideoAt,

--- a/lib/src/result/step/video_step_result.g.dart
+++ b/lib/src/result/step/video_step_result.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'video_step_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VideoStepResult _$VideoStepResultFromJson(Map<String, dynamic> json) =>
+    VideoStepResult(
+      id: Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      result: VideoResult.fromJson(json['result'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$VideoStepResultToJson(VideoStepResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'result': instance.result?.toJson(),
+    };
+
+VideoResult _$VideoResultFromJson(Map<String, dynamic> json) => VideoResult(
+      leftVideoAt: Duration(microseconds: json['leftVideoAt'] as int),
+      stayedInVideo: DateTime.parse(json['stayedInVideo'] as String),
+    );
+
+Map<String, dynamic> _$VideoResultToJson(VideoResult instance) =>
+    <String, dynamic>{
+      'leftVideoAt': instance.leftVideoAt.inMicroseconds,
+      'stayedInVideo': instance.stayedInVideo.toIso8601String(),
+    };

--- a/lib/src/result/step_result.dart
+++ b/lib/src/result/step_result.dart
@@ -1,15 +1,33 @@
+import 'package:survey_kit/src/result/question/boolean_question_result.dart';
+import 'package:survey_kit/src/result/question/date_question_result.dart';
+import 'package:survey_kit/src/result/question/double_question_result.dart';
+import 'package:survey_kit/src/result/question/integer_question_result.dart';
+import 'package:survey_kit/src/result/question/multiple_choice_question_result.dart';
+import 'package:survey_kit/src/result/question/multiple_double_question_result.dart';
+import 'package:survey_kit/src/result/question/scale_question_result.dart';
+import 'package:survey_kit/src/result/question/single_choice_question_result.dart';
+import 'package:survey_kit/src/result/question/text_question_result.dart';
+import 'package:survey_kit/src/result/question/time_question_result.dart';
 import 'package:survey_kit/src/result/result.dart';
+import 'package:survey_kit/src/result/step/completion_step_result.dart';
+import 'package:survey_kit/src/result/step/instruction_step_result.dart';
+import 'package:survey_kit/src/result/step/video_step_result.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 import 'package:survey_kit/src/result/question_result.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'step_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class StepResult extends Result {
+  @_Converter()
   final List<QuestionResult> results;
 
-  StepResult(
-      {required Identifier? id,
-      required DateTime startDate,
-      required DateTime endDate,
-      required this.results})
+  StepResult({required Identifier? id,
+    required DateTime startDate,
+    required DateTime endDate,
+    required this.results})
       : super(id: id, startDate: startDate, endDate: endDate);
 
   factory StepResult.fromQuestion({required QuestionResult questionResult}) {
@@ -19,5 +37,123 @@ class StepResult extends Result {
       endDate: questionResult.endDate,
       results: [questionResult],
     );
+  }
+
+  factory StepResult.fromJson(Map<String, dynamic> json) =>
+      _$StepResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StepResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate];
+}
+
+class _Converter implements JsonConverter<List<QuestionResult>, Object> {
+  const _Converter();
+
+  @override
+  Object toJson(List<QuestionResult> questionResults) {
+    List<Map<String, dynamic>> allQuestionResultsEncoded = [];
+
+    for (QuestionResult qr in questionResults) {
+      if (qr is BooleanQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (BooleanQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is DateQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (DateQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is DoubleQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (DoubleQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is IntegerQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (IntegerQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is MultipleDoubleQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (MultipleDoubleQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is MultipleDoubleQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (MultipleDoubleQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is ScaleQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (ScaleQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is SingleChoiceQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (SingleChoiceQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is TextQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (TextQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is TimeQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (TimeQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is InstructionStepResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (InstructionStepResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is CompletionStepResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (CompletionStepResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is VideoStepResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (VideoStepResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else {
+        throw ('Unhandled Question Result Type');
+      }
+    }
+
+    return allQuestionResultsEncoded;
+  }
+
+  @override
+  List<QuestionResult> fromJson(Object json) {
+    final List<QuestionResult> results = [];
+    for (var element in json as List<dynamic>) {
+      final qData = element as Map<String, dynamic>;
+      final qType = qData['type'] as String;
+
+      if (qType == (BooleanQuestionResult).toString()) {
+        results.add(BooleanQuestionResult.fromJson(qData));
+      } else if (qType == (DateQuestionResult).toString()) {
+        results.add(DateQuestionResult.fromJson(qData));
+      } else if (qType == (DoubleQuestionResult).toString()) {
+        results.add(DoubleQuestionResult.fromJson(qData));
+      } else if (qType == (IntegerQuestionResult).toString()) {
+        results.add(IntegerQuestionResult.fromJson(qData));
+      } else if (qType == (MultipleChoiceQuestionResult).toString()) {
+        results.add(MultipleChoiceQuestionResult.fromJson(qData));
+      } else if (qType == (MultipleDoubleQuestionResult).toString()) {
+        results.add(MultipleDoubleQuestionResult.fromJson(qData));
+      } else if (qType == (ScaleQuestionResult).toString()) {
+        results.add(ScaleQuestionResult.fromJson(qData));
+      } else if (qType == (SingleChoiceQuestionResult).toString()) {
+        results.add(SingleChoiceQuestionResult.fromJson(qData));
+      } else if (qType == (TextQuestionResult).toString()) {
+        results.add(TextQuestionResult.fromJson(qData));
+      } else if (qType == (TimeQuestionResult).toString()) {
+        results.add(TimeQuestionResult.fromJson(qData));
+      } else if (qType == (InstructionStepResult).toString()) {
+        results.add(InstructionStepResult.fromJson(qData));
+      } else if (qType == (CompletionStepResult).toString()) {
+        results.add(CompletionStepResult.fromJson(qData));
+      } else if (qType == (VideoStepResult).toString()) {
+        results.add(VideoStepResult.fromJson(qData));
+      } else {
+        throw ('Unhandled Question Result Type');
+      }
+    }
+
+    return results;
   }
 }

--- a/lib/src/result/step_result.g.dart
+++ b/lib/src/result/step_result.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'step_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StepResult _$StepResultFromJson(Map<String, dynamic> json) => StepResult(
+      id: json['id'] == null
+          ? null
+          : Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      results: const _Converter().fromJson(json['results'] as Object),
+    );
+
+Map<String, dynamic> _$StepResultToJson(StepResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'results': const _Converter().toJson(instance.results),
+    };

--- a/lib/src/result/survey/survey_result.dart
+++ b/lib/src/result/survey/survey_result.dart
@@ -2,6 +2,11 @@ import 'package:survey_kit/src/result/result.dart';
 import 'package:survey_kit/src/result/step_result.dart';
 import 'package:survey_kit/src/steps/identifier/identifier.dart';
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'survey_result.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class SurveyResult extends Result {
   final FinishReason finishReason;
   final List<StepResult> results;
@@ -13,6 +18,13 @@ class SurveyResult extends Result {
     required this.finishReason,
     required this.results,
   }) : super(id: id, startDate: startDate, endDate: endDate);
+  
+  factory SurveyResult.fromJson(Map<String, dynamic> json) => _$SurveyResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveyResultToJson(this);
+
+  @override
+  List<Object?> get props => [id, startDate, endDate, finishReason];
 }
 
 enum FinishReason { SAVED, DISCARDED, COMPLETED, FAILED }

--- a/lib/src/result/survey/survey_result.g.dart
+++ b/lib/src/result/survey/survey_result.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'survey_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SurveyResult _$SurveyResultFromJson(Map<String, dynamic> json) => SurveyResult(
+      id: json['id'] == null
+          ? null
+          : Identifier.fromJson(json['id'] as Map<String, dynamic>),
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      finishReason: $enumDecode(_$FinishReasonEnumMap, json['finishReason']),
+      results: (json['results'] as List<dynamic>)
+          .map((e) => StepResult.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$SurveyResultToJson(SurveyResult instance) =>
+    <String, dynamic>{
+      'id': instance.id?.toJson(),
+      'startDate': instance.startDate.toIso8601String(),
+      'endDate': instance.endDate.toIso8601String(),
+      'finishReason': _$FinishReasonEnumMap[instance.finishReason],
+      'results': instance.results.map((e) => e.toJson()).toList(),
+    };
+
+const _$FinishReasonEnumMap = {
+  FinishReason.SAVED: 'SAVED',
+  FinishReason.DISCARDED: 'DISCARDED',
+  FinishReason.COMPLETED: 'COMPLETED',
+  FinishReason.FAILED: 'FAILED',
+};

--- a/lib/src/steps/predefined_steps/instruction_step.dart
+++ b/lib/src/steps/predefined_steps/instruction_step.dart
@@ -7,7 +7,7 @@ import 'package:survey_kit/src/views/instruction_view.dart';
 
 part 'instruction_step.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class InstructionStep extends Step {
   final String title;
   final String text;

--- a/lib/src/steps/predefined_steps/instruction_step.g.dart
+++ b/lib/src/steps/predefined_steps/instruction_step.g.dart
@@ -23,7 +23,7 @@ InstructionStep _$InstructionStepFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$InstructionStepToJson(InstructionStep instance) =>
     <String, dynamic>{
-      'stepIdentifier': instance.stepIdentifier,
+      'stepIdentifier': instance.stepIdentifier.toJson(),
       'isOptional': instance.isOptional,
       'buttonText': instance.buttonText,
       'canGoBack': instance.canGoBack,

--- a/lib/src/views/multiple_double_answer_view.dart
+++ b/lib/src/views/multiple_double_answer_view.dart
@@ -76,7 +76,7 @@ class _MultipleDoubleAnswerViewState extends State<MultipleDoubleAnswerView> {
         startDate: _startDate,
         endDate: DateTime.now(),
         valueIdentifier: _controller.map((e) => e.text).join(', '),
-        results: _insertedValues,
+        result: _insertedValues,
       ),
       isValid: _isValid || widget.questionStep.isOptional,
       title: widget.questionStep.title.isNotEmpty

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   bloc:
     dependency: "direct main"
     description:
@@ -183,6 +183,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.3"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   bloc: ^8.0.3
   collection: ^1.15.0
   cupertino_icons: ^1.0.2
+  equatable: ^2.0.3
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.1

--- a/test/src/result/question/boolean_question_result_test.dart
+++ b/test/src/result/question/boolean_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = BooleanQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'bool1',
+    result: BooleanResult.NEGATIVE,
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = BooleanQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/date_question_result_test.dart
+++ b/test/src/result/question/date_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = DateQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'date1',
+    result: DateTime.now(),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+          () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = DateQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/double_question_result_test.dart
+++ b/test/src/result/question/double_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = DoubleQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'double1',
+    result: 123.45,
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+          () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = DoubleQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/integer_question_result_test.dart
+++ b/test/src/result/question/integer_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = IntegerQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'int1',
+    result: 123,
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+          () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = IntegerQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/multiple_choice_question_result_test.dart
+++ b/test/src/result/question/multiple_choice_question_result_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = MultipleChoiceQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'multiChoice1',
+    result: [
+      TextChoice(text: 'doubleVal1', value: '123.45'),
+      TextChoice(text: 'doubleVal2', value: '234.56'),
+    ],
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult =
+            MultipleChoiceQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/multiple_double_question_result_test.dart
+++ b/test/src/result/question/multiple_double_question_result_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = MultipleDoubleQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'multiDouble1',
+    result: [
+      MultiDouble(text: 'doubleVal1', value: 123.45),
+      MultiDouble(text: 'doubleVal2', value: 234.56),
+    ],
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult =
+            MultipleDoubleQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/scale_question_result_test.dart
+++ b/test/src/result/question/scale_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = ScaleQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'scaleInput1',
+    result: -123.45,
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = ScaleQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/single_choice_result_test.dart
+++ b/test/src/result/question/single_choice_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = SingleChoiceQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'singleChoiceValue1',
+    result: TextChoice(text: 'choice1', value: 'option2'),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = SingleChoiceQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/text_question_result_test.dart
+++ b/test/src/result/question/text_question_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = TextQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'textInput1',
+    result: 'some witty input  ',
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = TextQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/question/time_question_result_test.dart
+++ b/test/src/result/question/time_question_result_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = TimeQuestionResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    valueIdentifier: 'timeInput1',
+    result: TimeOfDay(hour: 14, minute: 59),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = TimeQuestionResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/step/completion_step_result_test.dart
+++ b/test/src/result/step/completion_step_result_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = CompletionStepResult(
+    Identifier(id: 'example1'),
+    DateTime(2022, 8, 12, 16, 4),
+    DateTime(2022, 8, 12, 16, 14),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+          () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = CompletionStepResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/step/instruction_step_result_test.dart
+++ b/test/src/result/step/instruction_step_result_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = InstructionStepResult(
+    Identifier(id: 'example1'),
+    DateTime(2022, 8, 12, 16, 4),
+    DateTime(2022, 8, 12, 16, 14),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+          () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = InstructionStepResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/result/step/video_step_result_test.dart
+++ b/test/src/result/step/video_step_result_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/src/result/step/video_step_result.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final tResult = VideoStepResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    result: VideoResult(
+      stayedInVideo: DateTime(2022, 8, 12, 16, 12, 30),
+      leftVideoAt: Duration(minutes: 1, seconds: 13, milliseconds: 123),
+    ),
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tResult.toJson();
+        final decodedResult = VideoStepResult.fromJson(encodedResult);
+        expect(tResult, decodedResult);
+      },
+    );
+  });
+}

--- a/test/src/survey/survey_result_test.dart
+++ b/test/src/survey/survey_result_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+void main() {
+  final List<QuestionResult> tQuestionResults = ([
+    InstructionStepResult(
+      Identifier(id: 'example1_intro'),
+      DateTime(2022, 8, 12, 16, 4),
+      DateTime(2022, 8, 12, 16, 5),
+    ),
+    BooleanQuestionResult(
+      id: Identifier(id: 'example1_boolean'),
+      startDate: DateTime(2022, 8, 12, 16, 5),
+      endDate: DateTime(2022, 8, 12, 16, 10),
+      valueIdentifier: 'bool1',
+      result: BooleanResult.NEGATIVE,
+    ),
+    CompletionStepResult(
+      Identifier(id: 'example1_completion'),
+      DateTime(2022, 8, 12, 16, 10),
+      DateTime(2022, 8, 12, 16, 14),
+    ),
+  ]);
+  final tSurveyResult = SurveyResult(
+    id: Identifier(id: 'example1'),
+    startDate: DateTime(2022, 8, 12, 16, 4),
+    endDate: DateTime(2022, 8, 12, 16, 14),
+    finishReason: FinishReason.COMPLETED,
+    results: [
+      StepResult(
+        id: Identifier(id: 'example1_stepResult'),
+        startDate: DateTime(2022, 8, 12, 16, 5),
+        endDate: DateTime(2022, 8, 12, 16, 10),
+        results: tQuestionResults,
+      ),
+    ],
+  );
+
+  group('serialisation', () {
+    test(
+      'should work with valid example',
+      () async {
+        final encodedResult = tSurveyResult.toJson();
+        final decodedResult = SurveyResult.fromJson(encodedResult);
+        expect(tSurveyResult, decodedResult);
+      },
+    );
+  });
+}


### PR DESCRIPTION
* minor fixes supporting serialisation

fixes issue with running build_runner after DoubleAnswer was renamed to MultiDouble

* added plugin: equatable, made Result and its subclasses extend Equatable

- instead of manually overriding operator == and hashCode one by one

* Serialisation for Result classes

Notes:

- IMPORTANT: when adding new Result subclasses, update the _Converter function in step_result.dart accordingly.
The toJson and fromJson functions there output and parse "type" field in order to distinguish between the different subclasses by that (rather than relying on heuristics in the result data field)

- the name of the result propery had to be streamlined in subclasses, e.g. instead of MultiDoubleQuestionResult.results and VideoStepResult.videoResult it's now .result
- and the explicitToJson option had to be added for the generation to work

* basic unit tests for checking the serialisation in the different Result subclasses

* updated readme

* fixed fromJson

- instruction, completion and video step results were missing
- implicit cast wrongly returned List<Result> instead List<QuestionResult>
- minor fix in a test + added a new case for SurveyResult level

Co-authored-by: Peter Megyesi <peter.megyesi@insight-centre.org>