### PR TITLE
Fixed consistent focus in non textfield views

### DIFF
--- a/lib/src/views/widget/step_view.dart
+++ b/lib/src/views/widget/step_view.dart
@@ -47,8 +47,13 @@ class StepView extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(vertical: 32.0),
                   child: OutlinedButton(
                     onPressed: isValid || step.isOptional
-                        ? () =>
-                            surveyController.nextStep(context, resultFunction)
+                        ? () => [
+                              FocusScope.of(context).hasFocus
+                                  ? FocusScope.of(context).unfocus()
+                                  : null,
+                              surveyController.nextStep(
+                                  context, resultFunction),
+                            ]
                         : null,
                     child: Text(
                       step.buttonText?.toUpperCase() ??


### PR DESCRIPTION
There was a problem that keyboard was not hiding after navigating to
next question when the view is not text/double answer view